### PR TITLE
Se valida token para el update y delete de un agente

### DIFF
--- a/controllers/agents.js
+++ b/controllers/agents.js
@@ -2,6 +2,7 @@ const agentsRouter = require("express").Router();
 const Agent = require("../models/agent");
 const Admin = require("../models/admin");
 const bcrypt = require("bcrypt");
+const jwt = require("jsonwebtoken");
 
 agentsRouter.get("/", async (req, res) => {
   const agents = await Agent.find({});
@@ -25,11 +26,82 @@ agentsRouter.get("/:id", async (req, res) => {
     : res.status(404).json({ test: "The agent does not exist" }).end();
 });
 
-agentsRouter.put("/:id", async (req, res) => {
-  const { id } = req.params;
-  const { ...update } = req.body;
+agentsRouter.put("/", async (req, res) => {
+  // const { id } = req.params;
+  const { agentID, ...update } = req.body;
+  console.log(update.permissions);
 
-  const agentUpdated = await Agent.findByIdAndUpdate(id, update, {
+  // Validación para actualizar datos del Agente_____________________________________
+  const authorization = req.get("authorization");
+  let token = null;
+
+  if (authorization && authorization.toLocaleLowerCase().startsWith("bearer")) {
+    // authorization = 'Bearer 46as4dq8w5e4q5w4x4'
+    // token = authorization.split(' ')[1] -> Otra forma de sacar el token
+    token = authorization.substring(7);
+  }
+
+  let decodedToken = {};
+  decodedToken = jwt.verify(token, process.env.SECRET);
+  const { userID, role } = decodedToken;
+
+  if (update.dni)
+    return res.status(403).json({ text: "You can not change the dni number" });
+
+  if (update.role) {
+    if (role === "AGENT")
+      return res.status(403).json({ text: "You can not change your role!" });
+    if (role === "ADMIN") {
+      const agentUpdated = await Agent.findByIdAndUpdate(agentID, update, {
+        new: true,
+      });
+      agentUpdated
+        ? res.json(agentUpdated).end()
+        : res.status(404).json({ test: "The agent does not exist" }).end();
+    }
+    return res.status(403).json({ text: "You do not have permissions!" });
+  }
+
+  if (update.permissions) {
+    if (role === "AGENT")
+      return res
+        .status(403)
+        .json({ text: "You can not change your permissions" });
+    if (role === "ADMIN") {
+      const agentUpdated = await Agent.findByIdAndUpdate(agentID, update, {
+        new: true,
+      });
+      agentUpdated
+        ? res.json(agentUpdated).end()
+        : res.status(404).json({ test: "The agent does not exist" }).end();
+    }
+  }
+
+  if (update.password && update.newPassword) {
+    if (role === "AGENT") {
+      const agent = await Agent.findById(userID);
+      const passwordCorrect = await bcrypt.compare(
+        update.password,
+        agent.password
+      );
+
+      if (!(agent && passwordCorrect)) {
+        return res
+          .status(401)
+          .json({ text: "Invalid agent or password" })
+          .end();
+      }
+
+      const newPasswordHash = await bcrypt.hash(update.newPassword, 10);
+      update.password = newPasswordHash;
+    }
+
+    return res
+      .status(403)
+      .json({ msg: "Only an agent, can change his password!" });
+  }
+
+  const agentUpdated = await Agent.findByIdAndUpdate(userID, update, {
     new: true,
   });
   agentUpdated
@@ -40,8 +112,27 @@ agentsRouter.put("/:id", async (req, res) => {
 agentsRouter.delete("/:id", async (req, res) => {
   const { id } = req.params;
 
-  await Agent.findByIdAndDelete(id);
-  res.status(200).end();
+  const authorization = req.get("authorization");
+  let token = null;
+
+  if (authorization && authorization.toLocaleLowerCase().startsWith("bearer")) {
+    // authorization = 'Bearer 46as4dq8w5e4q5w4x4'
+    // token = authorization.split(' ')[1] -> Otra forma de sacar el token
+    token = authorization.substring(7);
+  }
+
+  let decodedToken = {};
+  decodedToken = jwt.verify(token, process.env.SECRET);
+  const { role } = decodedToken;
+
+  if (role === "ADMIN") {
+    const agent = await Agent.findById(id);
+    agent.properties.length > 0
+      ? res.status(403).json({ msg: "Forbidden! The agent has properties" })
+      : (await Agent.findByIdAndDelete(id), res.status(200).end());
+  }
+
+  res.status(403).json({ msg: "You do not have permissions!" });
 });
 
 agentsRouter.post("/", async (req, res) => {

--- a/controllers/login.js
+++ b/controllers/login.js
@@ -49,8 +49,9 @@ loginRouter.post("/", async (req, res) => {
       return res.status(401).json({ text: "Invalid dni or password" }).end();
 
     const agentForToken = {
-      id: agent._id,
+      userID: agent._id,
       dni: agent.dni,
+      role: agent.role,
     };
 
     const token = jwt.sign(agentForToken, process.env.SECRET);
@@ -78,8 +79,9 @@ loginRouter.post("/", async (req, res) => {
       return res.status(401).json({ text: "Invalid dni or password" }).end();
 
     const adminForToken = {
-      id: admin._id,
+      userID: admin._id,
       dni: admin.dni,
+      role: admin.role,
     };
 
     const token = jwt.sign(adminForToken, process.env.SECRET);


### PR DESCRIPTION
Ahora para actualizar un agente funciona de dos formas:

La ruta para el update de un admin ya no requiere el ID del mismo, es decir; por params. (Lo obtengo del token decodificado)

Si el administrador quiere actualizar los datos de un agente, debe incluir por body el agentID.

Ejemplo:

PUT : http://localhost:3001/api/agents

{
    "agentID": "621d0fa294e6138e723aa2cb",
    "permissions": {
        "crudProperty": true
    }
}

SOLO un administrador puede eliminar un agente. La eliminación de un agente, solo se hace si este agente no tiene propiedades.

Para ver las demás validaciones del update de un agente, mirar el codigo. Acá escribí lo más importante del PR 😬

